### PR TITLE
check if paymentWall is defined

### DIFF
--- a/Views/frontend/_public/src/js/jquery.payment-wall-shipping-payment.js
+++ b/Views/frontend/_public/src/js/jquery.payment-wall-shipping-payment.js
@@ -23,10 +23,12 @@
         // reset the default
         $.loadingIndicator.defaults.closeOnClick = initialSetting;
 
-        if (approvalUrl) {
-            window.ppp = paymentWall($, approvalUrl.text());
-        } else {
-            window.ppp = paymentWall($);
+        if (typeof paymentWall === 'function') {
+            if (approvalUrl) {
+                window.ppp = paymentWall($, approvalUrl.text());
+            } else {
+                window.ppp = paymentWall($);
+            }
         }
 
         var paymentId = -1;


### PR DESCRIPTION
Check if paymentWall is defined cause in some cases if you return from confirm page to shipping selection approvalUrl is not defined, so template payment_paypal_plus/js-payment_wall.tpl is not loaded and caused an csrf token error